### PR TITLE
R - OPTIONS prompt

### DIFF
--- a/src/game/ingame_menu.c
+++ b/src/game/ingame_menu.c
@@ -2797,6 +2797,17 @@ void render_pause_castle_course_stars(s16 x, s16 y, s16 fileNum, s16 courseNum) 
     print_generic_string(x + 14, y + 13, str);
 }
 
+void render_pause_options_string() {
+    u8 textOptions[] = { 0x58, 0x9E, 0x9F, 0x9E, ASCII_TO_DIALOG('O'), ASCII_TO_DIALOG('P'), ASCII_TO_DIALOG('T'), ASCII_TO_DIALOG('I'), ASCII_TO_DIALOG('O'), ASCII_TO_DIALOG('N'), ASCII_TO_DIALOG('S'), DIALOG_CHAR_TERMINATOR };
+
+    gSPDisplayList(gDisplayListHead++, dl_ia_text_begin);
+    gDPSetEnvColor(gDisplayListHead++, 255, 255, 255, gDialogTextAlpha);
+
+    print_generic_string(get_str_x_pos_from_center(SCREEN_WIDTH / 2, textOptions, 1.0f), SCREEN_HEIGHT - 31, textOptions);
+
+    gSPDisplayList(gDisplayListHead++, dl_ia_text_end);
+}
+
 void render_pause_castle_main_strings(s16 x, s16 y) {
 #ifdef VERSION_EU
     u8 textCoin[] = { TEXT_COIN };
@@ -3090,6 +3101,7 @@ s16 render_pause_courses_and_castle(void) {
         case DIALOG_STATE_VERTICAL:
             if (!gDjuiPanelPauseCreated) {
                 shade_screen();
+                render_pause_options_string();
                 render_pause_my_score_coins();
                 render_pause_red_coins();
 
@@ -3131,6 +3143,7 @@ s16 render_pause_courses_and_castle(void) {
         case DIALOG_STATE_HORIZONTAL:
             if (!gDjuiPanelPauseCreated) {
                 shade_screen();
+                render_pause_options_string();
                 print_hud_pause_colorful_str();
 
                 if (gLevelValues.extendedPauseDisplay) {

--- a/src/pc/djui/djui.c
+++ b/src/pc/djui/djui.c
@@ -20,7 +20,6 @@
 static Gfx* sSavedDisplayListHead = NULL;
 
 struct DjuiRoot* gDjuiRoot = NULL;
-struct DjuiText* gDjuiPauseOptions = NULL;
 static struct DjuiText* sDjuiLuaError = NULL;
 static u32 sDjuiLuaErrorTimeout = 0;
 bool gDjuiInMainMenu = true;
@@ -29,7 +28,6 @@ bool gDjuiDisabled = false;
 bool gDjuiShuttingDown = false;
 bool gDjuiChangingTheme = false;
 static bool sDjuiInited = false;
-static struct DjuiRoot* sDjuiRootBehind = NULL;
 
 bool sDjuiRendered60fps = false;
 
@@ -38,9 +36,7 @@ void djui_shutdown(void) {
     djui_panel_shutdown();
 
     sSavedDisplayListHead = NULL;
-    if (gDjuiPauseOptions) djui_base_destroy(&gDjuiPauseOptions->base);
     if (sDjuiLuaError) djui_base_destroy(&sDjuiLuaError->base);
-    gDjuiPauseOptions = NULL;
     sDjuiLuaError = NULL;
     sDjuiLuaErrorTimeout = 0;
 
@@ -81,13 +77,6 @@ void patch_djui_interpolated(UNUSED f32 delta) {
 
 void djui_init(void) {
     gDjuiRoot = djui_root_create();
-    sDjuiRootBehind = djui_root_create();
-
-    gDjuiPauseOptions = djui_text_create(&sDjuiRootBehind->base, DLANG(MISC, R_BUTTON));
-    djui_base_set_size_type(&gDjuiPauseOptions->base, DJUI_SVT_RELATIVE, DJUI_SVT_ABSOLUTE);
-    djui_base_set_size(&gDjuiPauseOptions->base, 1.0f, 32);
-    djui_base_set_location(&gDjuiPauseOptions->base, 0, 16);
-    djui_text_set_alignment(gDjuiPauseOptions, DJUI_HALIGN_CENTER, DJUI_VALIGN_CENTER);
 
     sDjuiLuaError = djui_text_create(&gDjuiRoot->base, "");
     djui_base_set_size_type(&sDjuiLuaError->base, DJUI_SVT_RELATIVE, DJUI_SVT_ABSOLUTE);
@@ -158,10 +147,6 @@ void djui_render(void) {
 
     create_dl_ortho_matrix();
     djui_gfx_displaylist_begin();
-
-    if (sDjuiRootBehind != NULL && (sCurrPlayMode == PLAY_MODE_PAUSED) && !gDjuiPanelPauseCreated) {
-        djui_base_render(&sDjuiRootBehind->base);
-    }
 
     smlua_call_event_on_hud_render(djui_reset_hud_params);
 

--- a/src/pc/djui/djui.h
+++ b/src/pc/djui/djui.h
@@ -37,7 +37,6 @@
 #include "djui_paginated.h"
 
 extern struct DjuiRoot* gDjuiRoot;
-extern struct DjuiText* gDjuiPauseOptions;
 extern bool gDjuiInMainMenu;
 extern bool gDjuiInPlayerMenu;
 extern bool gDjuiDisabled;

--- a/src/pc/djui/djui_panel_menu_options.c
+++ b/src/pc/djui/djui_panel_menu_options.c
@@ -106,9 +106,6 @@ static void djui_panel_menu_options_djui_setting_change(UNUSED struct DjuiBase* 
         djui_panel_options_create(NULL);
         djui_panel_misc_create(NULL);
         djui_panel_main_menu_create(NULL);
-
-        djui_text_set_font(gDjuiPauseOptions, gDjuiFonts[configDjuiThemeFont == 0 ? FONT_NORMAL : FONT_ALIASED]);
-        djui_text_set_text(gDjuiPauseOptions, DLANG(MISC, R_BUTTON));
     }
     gDjuiChangingTheme = false;
 


### PR DESCRIPTION
removed the djui format R Button - Options prompt in place of a vanilla format R - OPTIONS prompt handled alongside all the vanilla pause text and R_TRIG detection